### PR TITLE
Adds support to phoenix 1.6 and removes support to phoenix 1.3.

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -38,7 +38,7 @@ defmodule SimpleAuth.Mixfile do
 
   defp deps do
     [
-      {:phoenix, "~> 1.3.0 or ~> 1.4.0 or ~> 1.5.0"},
+      {:phoenix, "~> 1.4.0 or ~> 1.5.0 or ~> 1.6.0"},
       {:comeonin, "~> 3.0"},
       {:exldap, "~> 0.4", optional: true},
       {:ex_doc, ">= 0.0.0", only: :dev},


### PR DESCRIPTION
#9 

The phoenix 1.4 was released on `Nov 07, 2018` as a new version from the `1.3` and I'm looking to have `simple_auth` available for phoenix `1.6`.

https://hex.pm/packages/phoenix/versions